### PR TITLE
Change urlToShare property type to allow Closure

### DIFF
--- a/src/Actions/SocialShareAction.php
+++ b/src/Actions/SocialShareAction.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\View\View;
 
 class SocialShareAction extends Action
 {
-    protected ?string $urlToShare = null;
+    protected string | null | Closure $urlToShare = null;
 
     protected ?string $text = null;
 


### PR DESCRIPTION
This pull request makes a small update to the `SocialShareAction` class, allowing the `$urlToShare` property to accept a `Closure` in addition to a string or null. This change increases flexibility for dynamic URL generation.