### PR TITLE
Drop PHP 8.2, add PHP 8.5 and Laravel 13 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [13.*, 12.*]
+        laravel: [12.*]
         stability: [prefer-stable]
         include:
-          - laravel: 13.*
-            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,10 +13,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [12.*]
+        php: [8.5, 8.4, 8.3]
+        laravel: [13.*, 12.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/filament": "^5.0|^4.0",
         "owenvoke/blade-fontawesome": "^2.9",
         "spatie/laravel-package-tools": "^1.15.0"
@@ -31,7 +31,7 @@
         "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^3.0||^2.34",
         "pestphp/pest-plugin-arch": "^3.0||^2.7",
         "pestphp/pest-plugin-laravel": "^3.0||^2.3",


### PR DESCRIPTION
## Summary

- Drop PHP 8.2 support; minimum is now PHP 8.3
- Add PHP 8.5 to the test matrix
- Add Laravel 13 support with the corresponding `orchestra/testbench` 11.x
- Update PHPStan workflow to run on PHP 8.5

## Changes

- **composer.json**: `php` constraint bumped to `^8.3`; testbench updated to `^11.0.0||^10.0.0||^9.0.0` (adds L13/testbench 11, drops L10/testbench 8)
- **run-tests.yml**: PHP matrix `[8.5, 8.4, 8.3]`, Laravel matrix `[13.*, 12.*]` with correct testbench mappings
- **phpstan.yml**: PHP version updated to `8.5`

## Test plan

- [ ] CI passes on PHP 8.3, 8.4, and 8.5 against Laravel 12 and 13
- [ ] PHPStan passes on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)